### PR TITLE
fix compilation error with base-4.8.*

### DIFF
--- a/src/Data/Heap.hs
+++ b/src/Data/Heap.hs
@@ -83,12 +83,19 @@ import Prelude hiding
     , span, dropWhile, takeWhile, break, filter, take, drop, splitAt
     , foldr, minimum, replicate, mapM
     , concatMap
+#if MIN_VERSION_base(4,8,0)
+    , traverse
+#endif
     )
 import qualified Data.List as L
 import Control.Applicative (Applicative(pure))
 import Control.Monad (liftM)
 import Data.Monoid (Monoid(mappend, mempty))
+#if MIN_VERSION_base(4,8,0)
+import Data.Foldable hiding (minimum, concatMap, null)
+#else
 import Data.Foldable hiding (minimum, concatMap)
+#endif
 import Data.Function (on)
 import Data.Data (DataType, Constr, mkConstr, mkDataType, Fixity(Prefix), Data(..), constrIndex)
 import Data.Typeable (Typeable)


### PR DESCRIPTION
This fixes the following compilation error with GHC-7.10 and base-4.8.*:

```
src/Data/Heap.hs:41:7:
    Ambiguous occurrence ‘null’
    It could refer to either ‘Data.Heap.null’,
                             defined at src/Data/Heap.hs:174:1
                          or ‘Data.Foldable.null’,
                             imported from ‘Data.Foldable’ at src/Data/Heap.hs:91:1-48
src/Data/Heap.hs:56:7:
    Ambiguous occurrence ‘traverse’
    It could refer to either ‘Data.Heap.traverse’,
                             defined at src/Data/Heap.hs:620:1
                          or ‘Traversable.traverse’,
                             imported from ‘Prelude’ at src/Data/Heap.hs:(81,1)-(86,5)
                             (and originally defined in ‘Data.Traversable’)
```
