### PR TITLE
Use cabal-docspec, always export the Heap version of null

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.11.20210101
+# version: 0.11.20210110
 #
-# REGENDATA ("0.11.20210101",["github","cabal.project"])
+# REGENDATA ("0.11.20210110",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -139,7 +139,7 @@ jobs:
       - name: cache (tools)
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-${{ matrix.ghc }}-tools-e66717b1
+          key: ${{ runner.os }}-${{ matrix.ghc }}-tools-c71e24d1
           path: ~/.haskell-ci-tools
       - name: install cabal-plan
         run: |
@@ -150,10 +150,15 @@ jobs:
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
-      - name: install doctest
+      - name: install cabal-docspec
         run: |
-          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then $CABAL --store-dir=$HOME/.haskell-ci-tools/store v2-install $ARG_COMPILER --ignore-project -j2 doctest --constraint='doctest ^>=0.17' ; fi
-          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then doctest --version ; fi
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20210110/cabal-docspec-0.0.0.20210110.xz > cabal-docspec.xz
+          echo 'e221737c49f539f5510d989fc597223ff9ea8230c358df666dc69ffa50713b73  cabal-docspec.xz' | sha256sum -c -
+          xz -d < cabal-docspec.xz > $HOME/.cabal/bin/cabal-docspec
+          rm -f cabal-docspec.xz
+          chmod a+x $HOME/.cabal/bin/cabal-docspec
+          cabal-docspec --version
       - name: install hlint
         run: |
           if [ $((HCNUMVER >= 81000)) -ne 0 ] ; then HLINTVER=$(cd /tmp && (${CABAL} v2-install -v $ARG_COMPILER --dry-run hlint  --constraint='hlint ==3.2.*' |  perl -ne 'if (/\bhlint-(\d+(\.\d+)*)\b/) { print "$1"; last; }')); echo "HLint version $HLINTVER" ; fi
@@ -204,10 +209,10 @@ jobs:
       - name: build
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
-      - name: doctest
+      - name: docspec
         run: |
-          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then cd ${PKGDIR_heaps} || false ; fi
-          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then doctest  src ; fi
+          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all
+          cabal-docspec $ARG_COMPILER
       - name: hlint
         run: |
           if [ $((HCNUMVER >= 81000)) -ne 0 ] ; then (cd ${PKGDIR_heaps} && hlint src) ; fi

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,16 @@
-next [????.??.??]
------------------
+0.4 [????.??.??]
+----------------
+* `heaps` now always exports a `null` function that is specialized to `Heap`,
+  i.e.,
+
+  ```haskell
+  null :: Heap a -> Bool
+  ```
+
+  Previously, this specialized versions of `null` was only exported with GHC
+  7.8 or older, and for more recent GHCs, the `Data.Foldable` version was
+  exported instead. The exported API is now uniform across all supported
+  versions of GHC.
 * Export `adjustMin`.
 
 0.3.6.1 [2019.02.05]

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,7 +1,7 @@
 no-tests-no-benchmarks: False
 unconstrained:          False
 allow-failures:         <7.3
-doctest:                True
+docspec:                True
 hlint:                  True
 irc-channels:           irc.freenode.org#haskell-lens
 irc-if-in-origin-repo:  True

--- a/heaps.cabal
+++ b/heaps.cabal
@@ -1,5 +1,5 @@
 name:           heaps
-version:        0.3.6.1
+version:        0.4
 license:        BSD3
 license-file:   LICENSE
 author:         Edward A. Kmett


### PR DESCRIPTION
Previously, we were exporting different versions of `null` depending on the GHC version being used—see the `CHANGELOG` entry for more details. We now always export `Data.Heap.null`.